### PR TITLE
feat: improve paste reliability and CLI compatibility for open issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Rust build artifacts
+rust/target/
+
+# Runtime temporary images
+temp/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - 🛡️ 图片读取边界保护：对 DIB 头与内存大小做安全校验，避免异常数据导致崩溃
 - 🪟 Windows 集成：内嵌多尺寸图标，并带 DPI-aware manifest，高 DPI 环境显示更稳定
 - 📁 Explorer 路径转换：在资源管理器复制文件后按 `Alt+V`，会粘贴对应 `/mnt/...` 路径
+- 🎯 路径格式可切换：纯路径 / `@` 前缀（适配 Kimi Code CLI、Gemini CLI、Qwen Code）/ 引号包裹
 
 ![clip_20260217_184919_809](./img/clip_20260217_184919_809.png)
 
@@ -132,6 +133,34 @@ WSL-Image-Clipboard-Helper/
 - 托盘菜单中的 `退出并清理临时图片` 会删除 `temp/` 下的临时 PNG 文件
 - 若遇到输入法导致的粘贴错乱，切回 `兼容模式（输入法保护）`
 - 若托盘图标未显示，请检查任务栏隐藏图标区域
+- 默认粘贴纯路径；Kimi 等需要 `@` 文件引用的 CLI，请在托盘菜单切换 `路径格式`
+
+### ❓ 常见问题（FAQ）
+
+**Q1：为什么有时显示 `[Image #1]`，有时却直接显示 `/mnt/...` 路径？**（[issue #4](https://github.com/cpulxb/WSL-Image-Clipboard-Helper/issues/4)）
+
+CLI Agent（Claude Code / Codex / OpenCode 等）收到粘贴文本的瞬间会检查该路径的文件是否已存在：存在就渲染成 `[Image #n]` 并直接作为图片附件（无需申请读取权限）；不存在或识别失败就原样留下路径文本，之后 Agent 只能用读文件工具去访问（触发权限申请；若 Agent 跑在 Windows 原生环境而非 WSL，还可能因不认识 `/mnt/c/...` 而再转换一次 Windows 路径，出现"二次申请"）。
+
+v4.0 及更早版本采用"先粘路径、后台再保存图片"的顺序，系统卡顿时文件落盘晚于 CLI 的检查，就会偶发直接显示路径。v4.1 起改为"先落盘、再粘贴"，从根本上消除该竞态。若仍偶发，请确认终端支持 bracketed paste（Windows Terminal 默认支持），并且 Agent 运行在 WSL 内。
+
+**Q2：按了热键，图片保存了、输入法也切换了，但哪里都粘不出文本？**（[issue #2](https://github.com/cpulxb/WSL-Image-Clipboard-Helper/issues/2)）
+
+按可能性从高到低排查：
+
+1. **在用 v3.0 AHK 版本（或自行改编译的版本）**：旧版粘贴后固定 80ms 就把剪贴板恢复成原图片，目标窗口响应稍慢时读到的已是恢复后的图片数据，表现为"任何地方都粘不出文本"。请升级到 v4.x Rust 版本（已移除该竞态）。
+2. **目标窗口以管理员权限运行**（如管理员终端），而本工具未提权：Windows UIPI 会静默拦截模拟按键。请以管理员身份运行本工具。
+3. **热键修饰键未松开**：Alt 未抬起时注入的 Ctrl+V 会被识别成 Ctrl+Alt+V 而失效。v4.1 增加了物理按键释放等待与 Alt 菜单屏蔽键，已大幅缓解。
+4. **安全软件拦截模拟键盘输入**（SendInput）：请将本工具加入白名单。
+
+**Q3：Kimi Code CLI 里粘贴路径没有变成图片？**（[issue #5](https://github.com/cpulxb/WSL-Image-Clipboard-Helper/issues/5)）
+
+Kimi Code CLI 不会把纯文本路径自动识别为图片，但支持 `@文件` 引用语法。在托盘菜单把 `路径格式` 切换为 `@ 路径（Kimi/Gemini/Qwen）`，热键会粘贴 `@/mnt/c/... `（带尾随空格），Kimi Code CLI / Gemini CLI / Qwen Code 即可把它作为文件引用消费。
+
+另外注意：Kimi Code CLI 在 Windows 端自带 `Alt+V` 贴图快捷键，与本工具默认热键相同。本工具注册的是系统级全局热键、会优先生效；若想保留 Kimi 原生行为，可在托盘把本工具热键换成 `Ctrl+Alt+V`。
+
+**Q4：路径里有空格，粘贴后被命令行截断？**
+
+把 `路径格式` 切换为 `引号路径`，粘贴时会用双引号包裹每个路径。
 
 ### 🛠️ Rust 版本编译（推荐）
 
@@ -180,7 +209,15 @@ cargo clean
 
 ### 🕒 版本历史
 
-#### v4.0（当前版本，Rust） ✅
+#### v4.1（开发中，Rust） 🚧
+
+- 修复偶发"粘贴出原始路径而非 `[Image #n]`"：改为图片先落盘、路径后粘贴，消除文件存在性竞态（#4）
+- 新增 `路径格式` 托盘选项：纯路径 / `@` 前缀 / 引号包裹，适配 Kimi Code CLI、Gemini CLI、Qwen Code 等（#5）
+- 粘贴按键注入加固：等待物理修饰键释放、增加 Alt 菜单屏蔽键并释放右 Alt，降低"粘贴无内容"概率（#2）
+- 支持在非 Windows 宿主上执行 `cargo check`/`cargo clippy`（自动跳过资源嵌入）
+- README 新增 FAQ 排障章节
+
+#### v4.0（当前发布版本，Rust） ✅
 
 - 主流程迁移到 Rust，可维护性更高
 - 修复 DIB 像素偏移解析问题，提升图片兼容性
@@ -234,6 +271,7 @@ Current mainline release is Rust-based (`v4.0`). The recommended path is to down
 - 🛡️ Safer clipboard parsing with memory-bound checks
 - 🪟 Embedded multi-size app icons and a DPI-aware manifest
 - 📁 Explorer file path conversion: copy files in Explorer, then press `Alt+V` to paste `/mnt/...` paths
+- 🎯 Switchable path style: plain / `@`-prefixed (for Kimi Code CLI, Gemini CLI, Qwen Code) / quoted
 
 ![clip_20260217_184919_809](./img/clip_20260217_184919_809.png)
 
@@ -297,6 +335,25 @@ WSL-Image-Clipboard-Helper/
 - `Exit and clean temporary images` removes temporary PNG files under `temp/`.
 - If IME state causes paste issues, switch back to `Compatibility mode (IME guard)`.
 - If the tray icon is not visible, check the hidden icons area in the Windows taskbar.
+- Plain paths are pasted by default; for CLIs that need `@` file references (e.g. Kimi Code CLI), switch `路径格式` (path style) in the tray menu.
+
+### ❓ FAQ
+
+**Q1: Why do I sometimes get `[Image #1]` and sometimes a literal `/mnt/...` path?** ([issue #4](https://github.com/cpulxb/WSL-Image-Clipboard-Helper/issues/4))
+
+CLI agents check whether the pasted path exists **at the moment the paste arrives**; if the file is there, it renders as an `[Image #n]` attachment, otherwise the raw path stays as text and the agent later needs file-read permission (and possibly a Windows-path retry when it runs outside WSL). Versions up to v4.0 pasted the path first and saved the PNG in the background, so under load the file could land after the check. Since v4.1 the image is written to disk **before** the path is pasted, removing that race.
+
+**Q2: Hotkey fires, the PNG appears in `temp/`, IME switches — but no text is pasted anywhere.** ([issue #2](https://github.com/cpulxb/WSL-Image-Clipboard-Helper/issues/2))
+
+Most likely causes, in order: (1) you are on the v3.0 AHK build, which restored the clipboard 80 ms after pasting — slow target windows read the restored image instead of the path text; upgrade to v4.x. (2) The target window runs elevated while the helper does not — Windows UIPI silently drops injected keys; run the helper as administrator. (3) Hotkey modifiers still held — injected Ctrl+V turns into Ctrl+Alt+V; v4.1 waits for physical key release and adds an Alt menu-mask key. (4) Security software blocking `SendInput`.
+
+**Q3: Kimi Code CLI does not turn the pasted path into an image.** ([issue #5](https://github.com/cpulxb/WSL-Image-Clipboard-Helper/issues/5))
+
+Kimi Code CLI does not auto-detect plain path text, but it supports `@file` references. Switch the tray `路径格式` (path style) to the `@` option and the hotkey pastes `@/mnt/c/... ` (with a trailing space), which Kimi Code CLI / Gemini CLI / Qwen Code consume as a file reference. Note Kimi's own Windows build binds `Alt+V` for clipboard images; this helper's global hotkey takes priority, so switch one of them (e.g. this helper to `Ctrl+Alt+V`) if you want both behaviors.
+
+**Q4: Paths containing spaces get cut off in the shell.**
+
+Switch the path style to the quoted option; every path is then wrapped in double quotes.
 
 If you prefer building from source:
 
@@ -330,6 +387,7 @@ cargo clean
 
 ### 🕒 Version Line
 
+- `v4.1` (in development): save-before-paste ordering fix (#4), switchable path style incl. `@` references for Kimi/Gemini/Qwen (#5), hardened key injection (#2)
 - `v4.0`: Rust mainline release with embedded multi-size icons, DPI-aware manifest, and Explorer-to-WSL path paste
 - `v3.0`: Hotkey-focused revision on AHK
 - `v2.0`: AHK path-first optimization

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "wsl_clipboard"
-version = "2.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsl_clipboard"
-version = "2.0.0"
+version = "4.1.0"
 edition = "2021"
 description = "WSL CLI Clipboard Helper - Fast image paste for AI agents"
 authors = ["liu"]
@@ -50,7 +50,9 @@ chrono = "0.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
-[target.'cfg(windows)'.build-dependencies]
+# winresource 仅在 Windows 宿主上真正编译资源（见 build.rs），
+# 放在通用 build-dependencies 里以支持从非 Windows 宿主交叉 cargo check
+[build-dependencies]
 winresource = "0.1"
 
 [features]

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -3,6 +3,15 @@ fn main() {
         return;
     }
 
+    // 资源编译依赖 Windows 上的 rc 工具链；
+    // 非 Windows 宿主跳过图标/manifest 嵌入，保证交叉 cargo check/clippy 可用
+    if std::env::var("HOST")
+        .map(|h| !h.contains("windows"))
+        .unwrap_or(true)
+    {
+        return;
+    }
+
     let mut resource = winresource::WindowsResource::new();
     resource.set_icon("assets/wsl_clipboard.ico");
     resource.set_manifest_file("app.manifest");

--- a/rust/src/clipboard.rs
+++ b/rust/src/clipboard.rs
@@ -63,7 +63,7 @@ impl ClipboardManager {
         unsafe { IsClipboardFormatAvailable(CF_HDROP.0 as u32) != 0 }
     }
 
-    pub fn read_file_list_for_paste(&self) -> Option<String> {
+    pub fn read_file_list_for_paste(&self) -> Option<Vec<String>> {
         let paths = self.get_file_paths()?;
         let wsl_paths: Vec<String> = paths
             .iter()
@@ -74,7 +74,7 @@ impl ClipboardManager {
         if wsl_paths.is_empty() {
             None
         } else {
-            Some(wsl_paths.join("\n"))
+            Some(wsl_paths)
         }
     }
 

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -13,6 +13,11 @@ pub struct AppConfig {
 
     /// 粘贴格式: "plain" (路径), "attachment" (附件)
     pub paste_format: PasteFormat,
+
+    /// 路径粘贴风格: "plain" (纯路径), "at" (@ 前缀), "quoted" (引号包裹)
+    /// 旧版配置文件没有该字段，缺省按 plain 处理
+    #[serde(default)]
+    pub path_style: PathStyle,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,12 +34,58 @@ pub enum PasteFormat {
     Attachment,
 }
 
+/// 路径粘贴风格
+/// - Plain: `/mnt/c/...`，Claude Code / Codex / OpenCode 可直接识别为图片
+/// - At: `@/mnt/c/... `，适配 Kimi Code CLI / Gemini CLI / Qwen Code 等 @ 文件引用语法
+/// - Quoted: `"/mnt/c/..."`，用于含空格路径或直接喂给 shell 命令
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PathStyle {
+    #[default]
+    Plain,
+    At,
+    Quoted,
+}
+
+impl PathStyle {
+    /// 将一组 WSL 路径格式化为最终粘贴文本
+    pub fn format_paths(&self, paths: &[String]) -> String {
+        match self {
+            PathStyle::Plain => paths.join("\n"),
+            PathStyle::Quoted => paths
+                .iter()
+                .map(|p| format!("\"{}\"", p))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            // @ 引用需要空格断词：多个路径用空格分隔，并保留尾随空格，
+            // 这样 CLI 能立刻结束文件引用解析，用户也可以直接继续输入
+            PathStyle::At => {
+                let joined = paths
+                    .iter()
+                    .map(|p| format!("@{}", p))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                format!("{} ", joined)
+            }
+        }
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            PathStyle::Plain => "纯路径（Claude/Codex/OpenCode）",
+            PathStyle::At => "@ 路径（Kimi/Gemini/Qwen）",
+            PathStyle::Quoted => "引号路径（含空格场景）",
+        }
+    }
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
             hotkey: "!v".to_string(),
             runtime_mode: RuntimeMode::Fast,
             paste_format: PasteFormat::Plain,
+            path_style: PathStyle::default(),
         }
     }
 }

--- a/rust/src/image_saver.rs
+++ b/rust/src/image_saver.rs
@@ -1,33 +1,30 @@
-use std::path::PathBuf;
-use tokio::sync::mpsc;
-use tracing::{info, warn};
+use anyhow::Context;
+use std::path::Path;
+use tracing::info;
 
-pub fn start_saver() -> mpsc::Sender<(PathBuf, Vec<u8>)> {
-    let (tx, mut rx) = mpsc::channel::<(PathBuf, Vec<u8>)>(64);
-
-    tokio::spawn(async move {
-        while let Some((path, data)) = rx.recv().await {
-            if let Err(e) = save_image(&path, &data).await {
-                warn!("保存图片失败 {}: {}", path.display(), e);
-            } else {
-                info!("图片已保存: {}", path.display());
-            }
-        }
-    });
-
-    tx
-}
-
-async fn save_image(path: &PathBuf, data: &[u8]) -> anyhow::Result<()> {
-    use anyhow::Context;
+/// 确保 PNG 数据已落盘。
+///
+/// 必须在粘贴路径**之前**调用：CLI Agent（Claude Code / Codex 等）收到粘贴文本的
+/// 瞬间会检查该路径文件是否存在，存在才会把它渲染成 `[Image #n]` 附件；
+/// 旧版“先粘路径、后台再写文件”的顺序在系统卡顿时会让文件晚于检查落盘，
+/// 表现为输入框里留下原始 `/mnt/...` 路径（issue #4）。
+///
+/// 剪贴板未变化的重复粘贴（缓存命中）文件已存在，直接跳过重写。
+pub async fn ensure_saved(path: &Path, data: &[u8]) -> anyhow::Result<()> {
+    if tokio::fs::try_exists(path).await.unwrap_or(false) {
+        return Ok(());
+    }
 
     if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .context("创建临时目录失败")?;
     }
 
     tokio::fs::write(path, data)
         .await
         .context("写入图片文件失败")?;
 
+    info!("图片已保存: {}", path.display());
     Ok(())
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,7 +1,6 @@
 #![windows_subsystem = "windows"]
 
 use anyhow::{Context, Result};
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{error, info, warn};
@@ -15,13 +14,14 @@ mod paste;
 mod tray;
 
 use clipboard::ClipboardManager;
-use config::RuntimeMode;
+use config::{PathStyle, RuntimeMode};
 use paste::HKL;
 use tray::TrayCommand;
 
 /// 应用运行时状态（可被托盘命令修改）
 struct AppState {
     runtime_mode: RuntimeMode,
+    path_style: PathStyle,
 }
 
 #[tokio::main]
@@ -30,7 +30,10 @@ async fn main() -> Result<()> {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    info!("WSL Clipboard Helper v2.0.0 (Rust) 启动中...");
+    info!(
+        "WSL Clipboard Helper v{} (Rust) 启动中...",
+        env!("CARGO_PKG_VERSION")
+    );
 
     // 加载配置
     let app_config = config::AppConfig::load().unwrap_or_default();
@@ -55,12 +58,10 @@ async fn main() -> Result<()> {
     // 创建剪贴板管理器
     let clipboard_manager = ClipboardManager::new(temp_dir.clone());
 
-    // 启动图片保存异步任务（不再需要 temp_dir 参数）
-    let save_tx = image_saver::start_saver();
-
     // 运行时状态
     let state = Arc::new(Mutex::new(AppState {
         runtime_mode: app_config.runtime_mode.clone(),
+        path_style: app_config.path_style,
     }));
 
     // 启动托盘（含热键管理器）
@@ -103,11 +104,11 @@ async fn main() -> Result<()> {
         tokio::select! {
             // 热键触发
             Some(_hotkey_id) = hotkey_rx.recv() => {
-                let mode = {
+                let (mode, path_style) = {
                     let s = state.lock().await;
-                    s.runtime_mode.clone()
+                    (s.runtime_mode.clone(), s.path_style)
                 };
-                match handle_paste(&clipboard_manager, &save_tx, &mode, english_hkl).await {
+                match handle_paste(&clipboard_manager, &mode, path_style, english_hkl).await {
                     Ok(_) => {}
                     Err(e) => {
                         error!("粘贴处理失败: {}", e);
@@ -124,6 +125,11 @@ async fn main() -> Result<()> {
                         info!("主循环: 模式已切换为 {:?}", mode);
                         let mut s = state.lock().await;
                         s.runtime_mode = mode;
+                    }
+                    TrayCommand::SwitchPathStyle(style) => {
+                        info!("主循环: 路径格式已切换为 {}", style.display_name());
+                        let mut s = state.lock().await;
+                        s.path_style = style;
                     }
                     TrayCommand::OpenFolder => {
                         if let Err(e) = tray::open_temp_folder() {
@@ -155,27 +161,28 @@ async fn main() -> Result<()> {
 /// 处理粘贴操作
 async fn handle_paste(
     clipboard_manager: &ClipboardManager,
-    save_tx: &mpsc::Sender<(PathBuf, Vec<u8>)>,
     mode: &RuntimeMode,
+    path_style: PathStyle,
     english_hkl: HKL,
 ) -> Result<()> {
     // 1. 检查剪贴板是否有图片
     if !clipboard_manager.has_image() {
         if clipboard_manager.has_file_list() {
             if let Some(wsl_paths) = clipboard_manager.read_file_list_for_paste() {
+                let paste_text = path_style.format_paths(&wsl_paths);
+
                 let _ime_guard = match mode {
                     RuntimeMode::Safe => Some(paste::ImeGuard::new(english_hkl)?),
                     RuntimeMode::Fast => None,
                 };
 
-                info!("粘贴文件路径: {}", wsl_paths);
-                paste::paste_text(&wsl_paths)?;
+                info!("粘贴文件路径: {}", paste_text);
+                paste::paste_text(&paste_text)?;
                 return Ok(());
             }
         }
 
         info!("剪贴板无图片，执行普通粘贴");
-        paste::release_all_modifiers();
         paste::send_ctrl_v()?;
         return Ok(());
     }
@@ -187,19 +194,21 @@ async fn handle_paste(
         .read_image_for_paste()
         .ok_or_else(|| anyhow::anyhow!("读取剪贴板图片失败"))?;
 
-    // 3. 输入法保护（仅安全模式）
+    // 3. 先落盘再粘贴：CLI 收到路径的瞬间会检查文件是否存在，
+    //    决定渲染成 [Image #n] 还是留下原始路径文本（issue #4）
+    info!("保存图片: {} bytes → {}", png_data.len(), win_path.display());
+    image_saver::ensure_saved(&win_path, &png_data).await?;
+
+    // 4. 输入法保护（仅安全模式）
     let _ime_guard = match mode {
         RuntimeMode::Safe => Some(paste::ImeGuard::new(english_hkl)?),
         RuntimeMode::Fast => None,
     };
 
-    // 4. 粘贴 WSL 路径
-    info!("粘贴路径: {}", wsl_path);
-    paste::paste_text(&wsl_path)?;
-
-    // 5. 异步保存图片
-    info!("保存图片: {} bytes → {}", png_data.len(), win_path.display());
-    let _ = save_tx.send((win_path, png_data)).await;
+    // 5. 粘贴 WSL 路径
+    let paste_text = path_style.format_paths(std::slice::from_ref(&wsl_path));
+    info!("粘贴路径: {}", paste_text);
+    paste::paste_text(&paste_text)?;
 
     // 6. ImeGuard 在此处 drop，触发 120ms 后恢复输入法
 

--- a/rust/src/paste.rs
+++ b/rust/src/paste.rs
@@ -6,8 +6,8 @@ use windows::Win32::System::DataExchange::{
 use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
 use windows::Win32::System::Ole::CF_UNICODETEXT;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, VIRTUAL_KEY, VK_CONTROL,
-    VK_LMENU, VK_MENU, VK_SHIFT, VK_V,
+    GetAsyncKeyState, SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,
+    VIRTUAL_KEY, VK_CONTROL, VK_LMENU, VK_MENU, VK_RMENU, VK_SHIFT, VK_V,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     GetForegroundWindow, GetWindowThreadProcessId, PostMessageW,
@@ -97,11 +97,44 @@ pub fn paste_text(text: &str) -> Result<()> {
     Ok(())
 }
 
+/// 菜单屏蔽键：与 AHK 的 A_MenuMaskKey（vkFF）一致。
+/// 热键触发时物理 Alt 往往仍按着，目标窗口只看到 Alt 按下（V 被热键吞掉），
+/// 若紧接着注入 Alt 抬起，部分程序会当成“单击 Alt”激活菜单栏、抢走输入焦点，
+/// 导致后续 Ctrl+V 粘不出内容。先注入一个无副作用的按键可打断该判定。
+const VK_MENU_MASK: VIRTUAL_KEY = VIRTUAL_KEY(0xFF);
+
+/// 检查某个虚拟键当前是否被物理按住
+fn is_key_down(vk: VIRTUAL_KEY) -> bool {
+    unsafe { (GetAsyncKeyState(vk.0 as i32) as u16 & 0x8000) != 0 }
+}
+
+/// 等待用户松开会污染 Ctrl+V 的物理修饰键（Alt/Shift），最多等待 timeout_ms。
+/// 物理按住的 Alt 会随键盘自动重复重新置为按下状态，仅靠注入抬起事件不总是够，
+/// 这是“偶发粘贴无内容”的常见来源之一。
+fn wait_modifiers_released(timeout_ms: u64) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    while is_key_down(VK_MENU)
+        || is_key_down(VK_LMENU)
+        || is_key_down(VK_RMENU)
+        || is_key_down(VK_SHIFT)
+    {
+        if std::time::Instant::now() >= deadline {
+            warn!("等待修饰键释放超时，继续注入粘贴按键");
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
 /// 释放所有修饰键（Alt/Ctrl/Shift），对应 AHK 的 NormalizeModifierStateBeforeSend
 pub fn release_all_modifiers() {
     let inputs = [
-        make_key_input(VK_MENU, true),    // Alt up
-        make_key_input(VK_LMENU, true),   // Left Alt up
+        // 先打菜单屏蔽键，再抬 Alt，避免“单击 Alt”激活窗口菜单
+        make_key_input(VK_MENU_MASK, false),
+        make_key_input(VK_MENU_MASK, true),
+        make_key_input(VK_MENU, true),     // Alt up
+        make_key_input(VK_LMENU, true),    // Left Alt up
+        make_key_input(VK_RMENU, true),    // Right Alt (AltGr) up
         make_key_input(VK_CONTROL, true),  // Ctrl up
         make_key_input(VK_SHIFT, true),    // Shift up
     ];
@@ -113,6 +146,9 @@ pub fn release_all_modifiers() {
 
 /// 发送 Ctrl+V 粘贴快捷键（使用 SendInput 替代 keybd_event）
 pub fn send_ctrl_v() -> Result<()> {
+    // 先给用户留出松开热键的时间（Alt+V/Alt+Enter 的 Alt 尚未抬起时，
+    // 注入的 Ctrl+V 会被识别成 Ctrl+Alt+V 而失效）
+    wait_modifiers_released(250);
     release_all_modifiers();
 
     let inputs = [

--- a/rust/src/tray.rs
+++ b/rust/src/tray.rs
@@ -1,5 +1,5 @@
 use crate::cleanup;
-use crate::config::{AppConfig, RuntimeMode};
+use crate::config::{AppConfig, PathStyle, RuntimeMode};
 use crate::hotkey::{HotkeyManager, HotkeyType};
 use anyhow::{Context, Result};
 use std::path::PathBuf;
@@ -26,12 +26,16 @@ const CMD_MODE_SAFE: u32 = 2001;
 const CMD_MODE_FAST: u32 = 2002;
 const CMD_OPEN_FOLDER: u32 = 3001;
 const CMD_EXIT: u32 = 4001;
+const CMD_STYLE_PLAIN: u32 = 5001;
+const CMD_STYLE_AT: u32 = 5002;
+const CMD_STYLE_QUOTED: u32 = 5003;
 
 /// 托盘发往主循环的命令
 #[derive(Debug, Clone)]
 pub enum TrayCommand {
     SwitchHotkey(HotkeyType),
     SwitchMode(RuntimeMode),
+    SwitchPathStyle(PathStyle),
     OpenFolder,
     Exit,
 }
@@ -318,6 +322,31 @@ unsafe fn show_context_menu(hwnd: HWND) {
     let mode_label: Vec<u16> = "运行模式\0".encode_utf16().collect();
     let _ = AppendMenuW(h_menu, MF_POPUP, h_mode_menu.0 as usize, PCWSTR::from_raw(mode_label.as_ptr()));
 
+    // ---- 路径格式子菜单 ----
+    let h_style_menu = match CreatePopupMenu() {
+        Ok(m) => m,
+        Err(_) => { let _ = DestroyMenu(h_menu); return; }
+    };
+
+    let current_style = state.config.path_style;
+    let style_items = [
+        (PathStyle::Plain, CMD_STYLE_PLAIN),
+        (PathStyle::At, CMD_STYLE_AT),
+        (PathStyle::Quoted, CMD_STYLE_QUOTED),
+    ];
+    for (style, cmd_id) in style_items {
+        let label = format!("{}\0", style.display_name());
+        let label_w: Vec<u16> = label.encode_utf16().collect();
+        let mut flags = MF_STRING;
+        if style == current_style {
+            flags |= MF_CHECKED;
+        }
+        let _ = AppendMenuW(h_style_menu, flags, cmd_id as usize, PCWSTR::from_raw(label_w.as_ptr()));
+    }
+
+    let style_label: Vec<u16> = "路径格式\0".encode_utf16().collect();
+    let _ = AppendMenuW(h_menu, MF_POPUP, h_style_menu.0 as usize, PCWSTR::from_raw(style_label.as_ptr()));
+
     // ---- 分隔线 ----
     let _ = AppendMenuW(h_menu, MF_SEPARATOR, 0, PCWSTR::null());
 
@@ -355,6 +384,9 @@ unsafe fn handle_menu_command(cmd_id: u32) {
         CMD_HOTKEY_ALTENTER => switch_hotkey(state, HotkeyType::AltEnter),
         CMD_MODE_SAFE => switch_mode(state, RuntimeMode::Safe),
         CMD_MODE_FAST => switch_mode(state, RuntimeMode::Fast),
+        CMD_STYLE_PLAIN => switch_path_style(state, PathStyle::Plain),
+        CMD_STYLE_AT => switch_path_style(state, PathStyle::At),
+        CMD_STYLE_QUOTED => switch_path_style(state, PathStyle::Quoted),
         CMD_OPEN_FOLDER => {
             let _ = state.cmd_tx.send(TrayCommand::OpenFolder);
         }
@@ -387,6 +419,19 @@ unsafe fn switch_hotkey(state: &mut TrayState, hotkey_type: HotkeyType) {
 
     let _ = state.cmd_tx.send(TrayCommand::SwitchHotkey(hotkey_type));
     info!("已切换热键: {}", hotkey_type.display_name());
+}
+
+/// 切换路径格式
+unsafe fn switch_path_style(state: &mut TrayState, style: PathStyle) {
+    if state.config.path_style == style {
+        return;
+    }
+
+    state.config.path_style = style;
+    let _ = state.config.save();
+
+    let _ = state.cmd_tx.send(TrayCommand::SwitchPathStyle(style));
+    info!("已切换路径格式: {}", style.display_name());
 }
 
 /// 切换模式

--- a/rust/wsl_clipboard.toml
+++ b/rust/wsl_clipboard.toml
@@ -1,3 +1,4 @@
 hotkey = "!Enter"
 runtime_mode = "safe"
 paste_format = "plain"
+path_style = "plain"

--- a/wsl_clipboard.toml
+++ b/wsl_clipboard.toml
@@ -1,3 +1,4 @@
 hotkey = "!v"
 runtime_mode = "fast"
 paste_format = "plain"
+path_style = "plain"

--- a/wsl_clipboard/wsl_clipboard.toml
+++ b/wsl_clipboard/wsl_clipboard.toml
@@ -1,3 +1,4 @@
 hotkey = "!v"
 runtime_mode = "fast"
 paste_format = "plain"
+path_style = "plain"


### PR DESCRIPTION
- Save the PNG to disk before pasting the path, so CLI agents find the file when they check existence on paste; fixes intermittent raw-path output instead of [Image #n] (#4)
- Harden key injection: wait for physical modifier release, inject an Alt menu-mask key before releasing Alt, and release right Alt, to reduce 'hotkey fires but nothing is pasted' cases (#2)
- Add tray-switchable path style: plain / @-prefixed (Kimi Code CLI, Gemini CLI, Qwen Code) / quoted (#5)
- Allow cargo check/clippy from non-Windows hosts by skipping resource embedding when the host is not Windows
- Add README FAQ covering the three issues; bump crate version to 4.1.0


Claude-Session: https://claude.ai/code/session_01WAVm93EtYXDh8axbKEqsi9